### PR TITLE
Autolaithe Text fix

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -168,7 +168,7 @@
 	category = list("initial","Tools")
 
 /datum/design/apc_board
-	name = "APC Module"
+	name = "Power Control Module"
 	id = "power control"
 	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(/datum/material/iron = 100, /datum/material/glass = 100)


### PR DESCRIPTION
# Document the changes in your pull request

Fixes the game-breaking issue where the power control module was named incorrectly in the autolaithe, making it hard to find.

# Wiki Documentation

N/A

# Changelog

Changes "APC Module" to "Power Control Module"  in the autolaithe for consistency

:cl:  
spellcheck: fixed a few typos  
/:cl:
